### PR TITLE
Change `sys.maxint` to `sys.maxsize` for Python 3

### DIFF
--- a/Mask to Master.py
+++ b/Mask to Master.py
@@ -31,7 +31,7 @@ def counterparts( selection, background ):
 		background = glyph_copy.layerForKey_( foregroundLayer.layerId ).background
 		background.decomposeComponents()
 	best_point_range = []
-	best_deviation = sys.maxint
+	best_deviation = sys.maxsize
 	# search in each path
 	for bg_path in background.paths:
 		bg_nodes = bg_path.nodes


### PR DESCRIPTION
`sys` in Python 3 does no longer provide a `maxint` attribute; Python 2 supports both `sys.maxint` and `sys.maxsize`. (See [Python 2 docs](https://docs.python.org/2.7/library/sys.html#sys.maxint) and [Python 3 docs](https://docs.python.org/3/library/sys.html#sys.maxsize).)

Without this change the code fail with error:

```
AttributeError: module 'sys' has no attribute 'maxint'
```

With the change the code works (tested in Glyphs 3 on macOS Big Sur, Python 3.8.2).